### PR TITLE
Adds a "clear history" button next to "search"

### DIFF
--- a/assets/scripts/search-history.js
+++ b/assets/scripts/search-history.js
@@ -3,6 +3,7 @@ var searchContainerEl = document.querySelector(".search-bar-dropdown-container")
 var historyDropdownEl = document.querySelector(".history-dropdown");
 var historyListEl = document.querySelector(".history-list");
 var submitButtonEl = document.querySelector(".artist-search-btn");
+var clearButtonEl = document.querySelector(".clear-history-btn");
 
 //if client has no history, set it to an empty array
 var clientSearchHistory = JSON.parse(localStorage.getItem("m-search-hist")) || [];
@@ -80,5 +81,13 @@ var addToSearchHistory = function (item) {
     localStorage.setItem("m-search-hist", JSON.stringify(clientSearchHistory));
     refreshSearchHistoryElement();
 }
+
+// FEATURE: Clear History
+
+clearButtonEl.addEventListener("click", () => {
+    //delete localStorage, then reload page to run init()
+    localStorage.removeItem("m-search-hist");
+    init();
+})
 
 init();

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -24,6 +24,19 @@
     transition: 0.1s ease;
 }
 
+/* FEATURE: Clear History */
+
+.clear-history-btn {
+    color: #fffcef;
+    background-color: #a33c3c;
+    transition: 0.1s ease;
+}
+
+.clear-history-btn:hover {
+    background-color: #a33c3c;
+    transition: 0.1s ease;
+}
+
 /* positions dropdown directly beneath search bar */
 .history-dropdown {
     display: none;

--- a/index.html
+++ b/index.html
@@ -44,6 +44,12 @@
 			>
 				Search
 			</button>
+			<!-- FEATURE: clear history button -->
+			<button
+				class="clear-history-btn bg-red-900 px-6 rounded-2xl mx-6 my-4 h-10"
+			>
+				Clear History
+			</button>
 		</form>
 		<div
 			class="card-container flex-wrap lg:w-3/4 md:w-3/4 sm:w-4/5 mx-auto justify-center hide"


### PR DESCRIPTION
Nick highlighted using localStorage in a standup so I wanted to add more to it.

Pretty simple button.  If clicked, it removes "m-search-hist" from localStorage.  Then, it runs init() which automatically recreates the original working structure for clientSearchHistory.  This is a common feature for search engines and doesn't interfere with page responsiveness.